### PR TITLE
CFG: rework terminators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ cpl=$(if $(filter linux,$(SYSTEM)),cp -l,cp -L)
 # We use a local directory rather than the final install path, since
 # the final install path may be on a different filesystem (and hence be
 # slow and/or unable to make hardlinks)
-.PHONY: _install
+.PHONY: _install install install_for_opam
 _install: compiler
 	rm -rf _install
 	mkdir -p _install/{bin,lib/ocaml}
@@ -177,6 +177,11 @@ _install: compiler
 
 # Copy _install to the final install directory (no-op if they are the same)
 install: _install
+	mkdir -p '$(prefix)'
+	rsync --chmod=u+rw,go+r -rl _install/ '$(prefix)'
+
+# Same as above, but relies on a successfull earlier _install
+install_for_opam:
 	mkdir -p '$(prefix)'
 	rsync --chmod=u+rw,go+r -rl _install/ '$(prefix)'
 

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -143,6 +143,13 @@ let replace_successor_labels t ~normal ~exn block ~f =
     in
     block.terminator <- { block.terminator with desc }
 
+let add_block_exn t block =
+  if Label.Tbl.mem t.blocks block.start
+  then
+    Misc.fatal_errorf "Cfr.add_block_exn: block %d is already present"
+      block.start;
+  Label.Tbl.add t.blocks block.start block
+
 let remove_block_exn t label =
   match Label.Tbl.find t.blocks label with
   | exception Not_found ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -111,6 +111,8 @@ val can_raise_interproc : basic_block -> bool
 
 val mem_block : t -> Label.t -> bool
 
+val add_block_exn : t -> basic_block -> unit
+
 val remove_block_exn : t -> Label.t -> unit
 
 val get_block : t -> Label.t -> basic_block option

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -158,10 +158,6 @@ val print_instruction :
 
 val can_raise_terminator : terminator -> bool
 
-val can_raise_basic : basic -> bool
-
-val can_raise_operation : operation -> bool
-
 val is_pure_terminator : terminator -> bool
 
 val is_pure_basic : basic -> bool

--- a/backend/cfg/cfg_deadcode.ml
+++ b/backend/cfg/cfg_deadcode.ml
@@ -1,0 +1,35 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+let live_before : type a. a Cfg.instruction -> liveness -> Reg.Set.t =
+ fun instr liveness ->
+  match Cfg_dataflow.Instr.Tbl.find_opt liveness instr.id with
+  | None -> fatal "no liveness information for instruction %d" instr.id
+  | Some { Cfg_liveness.before; across = _ } -> before
+
+let remove_deadcode (body : Instruction.t list) liveness used_after :
+    Instruction.t list =
+  List.fold_right body ~init:([], used_after)
+    ~f:(fun (instr : Instruction.t) (acc, used_after) ->
+      let before = live_before instr liveness in
+      let is_deadcode =
+        match instr.desc with
+        | Op _ as op ->
+          Cfg.is_pure_basic op
+          && Reg.disjoint_set_array used_after instr.res
+          && (not (Proc.regs_are_volatile instr.arg))
+          && not (Proc.regs_are_volatile instr.res)
+        | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
+      in
+      let acc = if is_deadcode then acc else instr :: acc in
+      acc, before)
+  |> fst
+
+let run cfg_with_layout =
+  let liveness = liveness_analysis cfg_with_layout in
+  Cfg.iter_blocks (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun _label block ->
+      block.body
+        <- remove_deadcode block.body liveness
+             (live_before block.terminator liveness));
+  cfg_with_layout

--- a/backend/cfg/cfg_deadcode.mli
+++ b/backend/cfg/cfg_deadcode.mli
@@ -1,0 +1,5 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* Dead code elimination: remove pure instructions whose results are not
+   used. *)
+val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -237,12 +237,6 @@ let check_operation : location -> Cfg.operation -> Cfg.operation -> unit =
     ()
   | Floatofint, Floatofint -> ()
   | Intoffloat, Intoffloat -> ()
-  | ( Probe
-        { name = expected_name; handler_code_sym = expected_handler_code_sym },
-      Probe { name = result_name; handler_code_sym = result_handler_code_sym } )
-    when String.equal expected_name result_name
-         && String.equal expected_handler_code_sym result_handler_code_sym ->
-    ()
   | ( Probe_is_enabled { name = expected_name },
       Probe_is_enabled { name = result_name } )
     when String.equal expected_name result_name ->
@@ -295,6 +289,12 @@ let check_prim_call_operation :
       Checkbound { immediate = result_immediate } )
     when Option.equal Int.equal expected_immediate result_immediate ->
     ()
+  | ( Probe
+        { name = expected_name; handler_code_sym = expected_handler_code_sym },
+      Probe { name = result_name; handler_code_sym = result_handler_code_sym } )
+    when String.equal expected_name result_name
+         && String.equal expected_handler_code_sym result_handler_code_sym ->
+    ()
   | _ -> different location "primitive call operation"
  [@@ocaml.warning "-4"]
 
@@ -310,37 +310,10 @@ let check_func_call_operation :
   | _ -> different location "function call operation"
  [@@ocaml.warning "-4"]
 
-let check_tail_call_operation :
-    State.t ->
-    location ->
-    Cfg.tail_call_operation ->
-    Cfg.tail_call_operation ->
-    unit =
- fun state location expected result ->
-  match expected, result with
-  | ( Self { destination = expected_destination },
-      Self { destination = result_destination } ) ->
-    State.add_labels_to_check state location expected_destination
-      result_destination
-  | Func expected_func, Func result_func ->
-    check_func_call_operation location expected_func result_func
-  | _ -> different location "tail call operation"
- [@@ocaml.warning "-4"]
-
-let check_call_operation :
-    location -> Cfg.call_operation -> Cfg.call_operation -> unit =
- fun location expected result ->
-  match expected, result with
-  | P expected, P result -> check_prim_call_operation location expected result
-  | F expected, F result -> check_func_call_operation location expected result
-  | _ -> different location "call operation"
- [@@ocaml.warning "-4"]
-
 let check_basic : State.t -> location -> Cfg.basic -> Cfg.basic -> unit =
  fun state location expected result ->
   match expected, result with
   | Op expected, Op result -> check_operation location expected result
-  | Call expected, Call result -> check_call_operation location expected result
   | Reloadretaddr, Reloadretaddr -> ()
   | ( Pushtrap { lbl_handler = expected_lbl_handler },
       Pushtrap { lbl_handler = result_lbl_handler } ) ->
@@ -397,7 +370,6 @@ let check_basic_instruction :
   let check_live =
     match result.desc with
     | Op _ -> true
-    | Call _ -> true
     | Reloadretaddr -> true
     | Pushtrap _ -> false
     | Poptrap -> false
@@ -481,18 +453,34 @@ let check_terminator_instruction :
     Array.iter2 (fun l1 l2 -> State.add_to_explore state l1 l2) a1 a2
   | Return, Return -> ()
   | Raise rk1, Raise rk2 when equal_raise_kind rk1 rk2 -> ()
+  | ( Tailcall_self { destination = expected_destination },
+      Tailcall_self { destination = result_destination } ) ->
+    State.add_to_explore state expected_destination result_destination
   | Tailcall tc1, Tailcall tc2 ->
     let location = location ^ " (terminator)" in
-    check_tail_call_operation state location tc1 tc2
+    check_func_call_operation location tc1 tc2
   | Call_no_return cn1, Call_no_return cn2 ->
     check_external_call_operation location cn1 cn2
+  | ( Call { call = cn1; label_after = lbl1 },
+      Call { call = cn2; label_after = lbl2 } ) ->
+    check_func_call_operation location cn1 cn2;
+    State.add_to_explore state lbl1 lbl2
+  | ( Prim { prim = cn1; label_after = lbl1 },
+      Prim { prim = cn2; label_after = lbl2 } ) ->
+    check_prim_call_operation location cn1 cn2;
+    State.add_to_explore state lbl1 lbl2
+  | ( Specific_can_raise { op = op1; label_after = lbl1 },
+      Specific_can_raise { op = op2; label_after = lbl2 } )
+    when Arch.equal_specific_operation op1 op2 ->
+    State.add_to_explore state lbl1 lbl2
   | _ -> different location "terminator");
   (* CR xclerc for xclerc: temporary, for testing *)
   let check_arg =
     match expected.desc with
     | Always _ -> false
     | Never | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-    | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
+    | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall _
+    | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _ ->
       true
   in
   check_instruction ~check_live:false ~check_dbg:false ~check_arg (-1) location

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -34,10 +34,6 @@ module S = struct
     | Indirect
     | Direct of { func_symbol : string }
 
-  type tail_call_operation =
-    | Self of { destination : Label.t }
-    | Func of func_call_operation
-
   type external_call_operation =
     { func_symbol : string;
       alloc : bool;
@@ -53,6 +49,10 @@ module S = struct
           mode : Lambda.alloc_mode
         }
     | Checkbound of { immediate : int option }
+    | Probe of
+        { name : string;
+          handler_code_sym : string
+        }
 
   type operation =
     | Move
@@ -75,10 +75,6 @@ module S = struct
     | Compf of Mach.float_comparison (* CR gyorsh: can merge with float_test? *)
     | Floatofint
     | Intoffloat
-    | Probe of
-        { name : string;
-          handler_code_sym : string
-        }
     | Probe_is_enabled of { name : string }
     | Opaque
     | Begin_region
@@ -90,10 +86,6 @@ module S = struct
           provenance : unit option;
           is_assignment : bool
         }
-
-  type call_operation =
-    | P of prim_call_operation
-    | F of func_call_operation
 
   type bool_test =
     { ifso : Label.t;  (** if test is true goto [ifso] label *)
@@ -144,9 +136,9 @@ module S = struct
       mutable irc_work_list : irc_work_list
     }
 
+  (* [basic] instruction cannot raise *)
   type basic =
     | Op of operation
-    | Call of call_operation
     | Reloadretaddr
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap
@@ -174,8 +166,23 @@ module S = struct
     | Switch of Label.t array
     | Return
     | Raise of Lambda.raise_kind
-    | Tailcall of tail_call_operation
+    | Tailcall_self of { destination : Label.t }
+    | Tailcall of func_call_operation
     | Call_no_return of external_call_operation
+    | Call of
+        { call : func_call_operation;
+          (* CR-someday azewierzejw: Maybe we would want to extract the pattern
+             [{x; label_after}]. *)
+          label_after : Label.t
+        }
+    | Prim of
+        { prim : prim_call_operation;
+          label_after : Label.t
+        }
+    | Specific_can_raise of
+        { op : Arch.specific_operation;
+          label_after : Label.t
+        }
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg/cfg_irc_split.ml
+++ b/backend/cfg/cfg_irc_split.ml
@@ -8,20 +8,20 @@ let naive_split_points : Cfg_with_layout.t -> Instruction.id list =
  fun cfg_with_layout ->
   if irc_debug then log ~indent:1 "naive_split_points";
   Cfg_with_layout.fold_instructions cfg_with_layout ~init:[]
-    ~instruction:(fun acc (instr : Instruction.t) ->
+    ~instruction:(fun acc _instr -> acc)
+    ~terminator:(fun acc term ->
       (* CR xclerc for xclerc: we may want to split [heuristically] in more
          situations. *)
       let split =
-        match instr.desc with
-        | Call (P (External _) | F (Direct _)) -> true
+        match term.desc with
+        | Call { call = Direct _; _ } | Prim { prim = External _; _ } -> true
         | _ -> false
       in
       if split
       then (
-        if irc_debug then log ~indent:2 "should split at %d" instr.id;
-        instr.id :: acc)
+        if irc_debug then log ~indent:2 "should split at %d" term.id;
+        term.id :: acc)
       else acc)
-    ~terminator:(fun acc _term -> acc)
   |> List.rev
 
 type naive_split_instr =

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -136,14 +136,13 @@ let is_move_basic : Cfg.basic -> bool =
     | Compf _ -> false
     | Floatofint -> false
     | Intoffloat -> false
-    | Probe _ -> false
     | Probe_is_enabled _ -> false
     | Opaque -> false
     | Begin_region -> false
     | End_region -> false
     | Specific _ -> false
     | Name_for_debugger _ -> false)
-  | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
+  | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
 
 let is_move_instruction : Cfg.basic Cfg.instruction -> bool =
  fun instr -> is_move_basic instr.desc

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -64,15 +64,14 @@ struct
       (* If the operation is without side-effects and the result is unused then
          the arguments also aren't necessary. *)
       { before; across = before }
-    else
-      instruction ~can_raise:(Cfg.can_raise_basic instr.desc) ~exn domain instr
+    else instruction ~can_raise:false ~exn domain instr
 
   let terminator :
       domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain =
    fun domain ~exn instr ->
     match instr.desc with
     | Never -> assert false
-    | Tailcall (Self _) ->
+    | Tailcall_self _ ->
       (* CR-someday azewierzejew: If the stamps for the tail call DomainState
          argument and parameter were the same and Tailcall (Self _) had
          [instr.arg = instr.reg] (either by removing the args or adding results

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -100,9 +100,10 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
      we are making an arbitrary choice. *)
   (* If one of the successors is a fallthrough label, do not emit a jump for it.
      Otherwise, the last jump is unconditional. *)
-  let branch_or_fallthrough lbl =
-    if Label.equal next.label lbl then [] else [L.Lbranch lbl]
+  let branch_or_fallthrough d lbl =
+    if Label.equal next.label lbl then d else d @ [L.Lbranch lbl]
   in
+  let single d = [d], None in
   let emit_bool (c1, l1) (c2, l2) =
     (* c1 must be the inverse of c2 *)
     match Label.equal l1 next.label, Label.equal l2 next.label with
@@ -116,22 +117,42 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
   in
   let desc_list, tailrec_label =
     match terminator.desc with
-    | Return -> [L.Lreturn], None
-    | Raise kind -> [L.Lraise kind], None
-    | Tailcall (Func Indirect) -> [L.Lop Itailcall_ind], None
-    | Tailcall (Func (Direct { func_symbol })) ->
-      [L.Lop (Itailcall_imm { func = func_symbol })], None
-    | Tailcall (Self { destination }) ->
+    | Return -> single L.Lreturn
+    | Raise kind -> single (L.Lraise kind)
+    | Tailcall Indirect -> single (L.Lop Itailcall_ind)
+    | Tailcall (Direct { func_symbol }) ->
+      single (L.Lop (Itailcall_imm { func = func_symbol }))
+    | Tailcall_self { destination } ->
       [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg })], Some destination
     | Call_no_return { func_symbol; alloc; ty_args; ty_res } ->
-      ( [ L.Lop
-            (Iextcall
-               { func = func_symbol; alloc; ty_args; ty_res; returns = false })
-        ],
-        None )
-    | Switch labels -> [L.Lswitch labels], None
+      single
+        (L.Lop
+           (Iextcall
+              { func = func_symbol; alloc; ty_args; ty_res; returns = false }))
+    | Call { call; label_after } ->
+      let d =
+        match call with
+        | Indirect -> L.Lop Icall_ind
+        | Direct { func_symbol } -> L.Lop (Icall_imm { func = func_symbol })
+      in
+      branch_or_fallthrough [d] label_after, None
+    | Prim { prim; label_after } ->
+      let d : Mach.operation =
+        match prim with
+        | External { func_symbol; alloc; ty_args; ty_res } ->
+          Iextcall
+            { func = func_symbol; alloc; ty_args; ty_res; returns = true }
+        | Checkbound { immediate = None } -> Iintop Icheckbound
+        | Checkbound { immediate = Some i } -> Iintop_imm (Icheckbound, i)
+        | Alloc { bytes; dbginfo; mode } -> Ialloc { bytes; dbginfo; mode }
+        | Probe { name; handler_code_sym } -> Iprobe { name; handler_code_sym }
+      in
+      branch_or_fallthrough [Lop d] label_after, None
+    | Specific_can_raise { op; label_after } ->
+      branch_or_fallthrough [Lop (Ispecific op)] label_after, None
+    | Switch labels -> single (L.Lswitch labels)
     | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
-    | Always label -> branch_or_fallthrough label, None
+    | Always label -> branch_or_fallthrough [] label, None
     | Parity_test { ifso; ifnot } ->
       emit_bool (Ieventest, ifso) (Ioddtest, ifnot), None
     | Truth_test { ifso; ifnot } ->
@@ -143,7 +164,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
       in
       match Label.Set.cardinal successor_labels with
       | 0 -> assert false
-      | 1 -> branch_or_fallthrough (Label.Set.min_elt successor_labels), None
+      | 1 -> branch_or_fallthrough [] (Label.Set.min_elt successor_labels), None
       | 2 | 3 | 4 ->
         let must_be_last, any =
           Label.Set.fold
@@ -186,7 +207,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
               else Some (L.Lcondbranch (Ifloattest c, lbl)))
             any
         in
-        branches @ branch_or_fallthrough last, None
+        branches @ branch_or_fallthrough [] last, None
       | _ -> assert false)
     | Int_test { lt; eq; gt; imm; is_signed } -> (
       let successor_labels =
@@ -194,7 +215,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
       in
       match Label.Set.cardinal successor_labels with
       | 0 -> assert false
-      | 1 -> branch_or_fallthrough (Label.Set.min_elt successor_labels), None
+      | 1 -> branch_or_fallthrough [] (Label.Set.min_elt successor_labels), None
       | 2 | 3 ->
         (* If fallthrough label is a successor, do not emit a jump for it.
            Otherwise, the last jump could be unconditional. *)
@@ -219,7 +240,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
           let find l = if Label.equal next.label l then None else Some l in
           [L.Lcondbranch3 (find lt, find eq, find gt)], None
         else
-          let init = branch_or_fallthrough last in
+          let init = branch_or_fallthrough [] last in
           ( Label.Set.fold
               (fun lbl acc ->
                 let cond =
@@ -259,18 +280,19 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
          immediately prior to this block. *)
       (* No need for the label, unless the predecessor's terminator is [Switch]
          when the label is needed for the jump table. *)
-      (* CR-someday gyorsh: is this correct with label_after for calls? *)
       match prev_block.terminator.desc with
       | Switch _ -> true
       | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
-      | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ ->
+      | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+      | Call _ | Prim _ | Specific_can_raise _ ->
         (* If the label came from the original [Linear] code, preserve it for
            checking that the conversion from [Linear] to [Cfg] and back is the
            identity; and for various assertions in reorder. *)
         let new_labels = CL.new_labels cfg_with_layout in
         CL.preserve_orig_labels cfg_with_layout
         && not (Label.Set.mem block.start new_labels)
-      | Return | Raise _ | Tailcall _ | Call_no_return _ -> assert false)
+      | Return | Raise _ | Tailcall _ | Tailcall_self _ | Call_no_return _ ->
+        assert false)
 
 let adjust_stack_offset body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -6,16 +6,6 @@ let from_basic (basic : basic) : Linear.instruction_desc =
   | Reloadretaddr -> Lreloadretaddr
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }
   | Poptrap -> Lpoptrap
-  | Call (F Indirect) -> Lop Icall_ind
-  | Call (F (Direct { func_symbol })) -> Lop (Icall_imm { func = func_symbol })
-  | Call (P (External { func_symbol; alloc; ty_args; ty_res })) ->
-    Lop
-      (Iextcall { func = func_symbol; alloc; ty_args; ty_res; returns = true })
-  | Call (P (Checkbound { immediate = None })) -> Lop (Iintop Icheckbound)
-  | Call (P (Checkbound { immediate = Some i })) ->
-    Lop (Iintop_imm (Icheckbound, i))
-  | Call (P (Alloc { bytes; dbginfo; mode })) ->
-    Lop (Ialloc { bytes; dbginfo; mode })
   | Op op ->
     let op : Mach.operation =
       match op with
@@ -39,7 +29,6 @@ let from_basic (basic : basic) : Linear.instruction_desc =
       | Compf c -> Icompf c
       | Floatofint -> Ifloatofint
       | Intoffloat -> Iintoffloat
-      | Probe { name; handler_code_sym } -> Iprobe { name; handler_code_sym }
       | Probe_is_enabled { name } -> Iprobe_is_enabled { name }
       | Opaque -> Iopaque
       | Specific op -> Ispecific op

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -60,6 +60,19 @@ let remove_block t label =
   t.layout <- List.filter (fun l -> not (Label.equal l label)) t.layout;
   t.new_labels <- Label.Set.remove label t.new_labels
 
+let add_block t (block : Cfg.basic_block) ~after =
+  t.new_labels <- Label.Set.add block.start t.new_labels;
+  let initial_len = List.length t.layout in
+  t.layout
+    <- List.fold_right
+         (fun label layout ->
+           if Label.equal label after
+           then label :: block.start :: layout
+           else label :: layout)
+         t.layout [];
+  assert (List.length t.layout = initial_len + 1);
+  Cfg.add_block_exn t.cfg block
+
 let is_trap_handler t label =
   let block = Cfg.get_block_exn t.cfg label in
   block.is_trap_handler

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -44,6 +44,9 @@ val new_labels : t -> Label.Set.t
 
 val set_layout : t -> Label.t list -> unit
 
+(** Add to cfg, layout, and other data-structures that track labels. *)
+val add_block : t -> Cfg.basic_block -> after:int -> unit
+
 (** Remove from cfg, layout, and other data-structures that track labels. *)
 val remove_block : t -> Label.t -> unit
 

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -194,7 +194,12 @@ let basic_or_terminator_of_operation :
   | Idivf -> Basic (Op Divf)
   | Ifloatofint -> Basic (Op Floatofint)
   | Iintoffloat -> Basic (Op Intoffloat)
-  | Ispecific op -> Basic (Op (Specific op))
+  | Ispecific op ->
+    if Arch.operation_can_raise op
+    then
+      With_next_label
+        (fun label_after -> Specific_can_raise { op; label_after })
+    else Basic (Op (Specific op))
   | Iopaque -> Basic (Op Opaque)
   | Iname_for_debugger _ ->
     Misc.fatal_error

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -129,6 +129,7 @@ end
 type basic_or_terminator =
   | Basic of Cfg.basic
   | Terminator of Cfg.terminator
+  | With_next_label of (Label.t -> Cfg.terminator)
 
 let basic_or_terminator_of_operation :
     State.t -> Mach.operation -> basic_or_terminator =
@@ -140,28 +141,41 @@ let basic_or_terminator_of_operation :
   | Iconst_int i -> Basic (Op (Const_int i))
   | Iconst_float f -> Basic (Op (Const_float f))
   | Iconst_symbol s -> Basic (Op (Const_symbol s))
-  | Icall_ind -> Basic (Call (F Indirect))
-  | Icall_imm { func } -> Basic (Call (F (Direct { func_symbol = func })))
-  | Itailcall_ind -> Terminator (Tailcall (Func Indirect))
+  | Icall_ind ->
+    With_next_label
+      (fun label_after -> Cfg.Call { call = Indirect; label_after })
+  | Icall_imm { func } ->
+    With_next_label
+      (fun label_after ->
+        Cfg.Call { call = Direct { func_symbol = func }; label_after })
+  | Itailcall_ind -> Terminator (Tailcall Indirect)
   | Itailcall_imm { func } ->
     Terminator
-      (Tailcall
-         (if String.equal (State.get_fun_name state) func
-         then Self { destination = State.get_tailrec_label state }
-         else Func (Direct { func_symbol = func })))
+      (if String.equal (State.get_fun_name state) func
+      then Tailcall_self { destination = State.get_tailrec_label state }
+      else Tailcall (Direct { func_symbol = func }))
   | Iextcall { func; ty_res; ty_args; alloc; returns } ->
     let external_call = { Cfg.func_symbol = func; alloc; ty_res; ty_args } in
     if returns
-    then Basic (Call (P (External external_call)))
+    then
+      With_next_label
+        (fun label_after -> Prim { prim = External external_call; label_after })
     else Terminator (Call_no_return external_call)
   | Istackoffset ofs -> Basic (Op (Stackoffset ofs))
   | Iload (mem, mode, mut) -> Basic (Op (Load (mem, mode, mut)))
   | Istore (mem, mode, assignment) -> Basic (Op (Store (mem, mode, assignment)))
   | Ialloc { bytes; dbginfo; mode } ->
-    Basic (Call (P (Alloc { bytes; dbginfo; mode })))
-  | Iintop Icheckbound -> Basic (Call (P (Checkbound { immediate = None })))
+    With_next_label
+      (fun label_after ->
+        Prim { prim = Alloc { bytes; dbginfo; mode }; label_after })
+  | Iintop Icheckbound ->
+    With_next_label
+      (fun label_after ->
+        Prim { prim = Checkbound { immediate = None }; label_after })
   | Iintop_imm (Icheckbound, i) ->
-    Basic (Call (P (Checkbound { immediate = Some i })))
+    With_next_label
+      (fun label_after ->
+        Prim { prim = Checkbound { immediate = Some i }; label_after })
   | Iintop
       (( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
        | Ilsr | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) as op) ->
@@ -187,7 +201,9 @@ let basic_or_terminator_of_operation :
       "Cfgize.basic_or_terminator_of_operation: \"the Iname_for_debugger\" \
        instruction is currently not supported "
   | Iprobe { name; handler_code_sym } ->
-    Basic (Op (Probe { name; handler_code_sym }))
+    With_next_label
+      (fun label_after ->
+        Prim { prim = Probe { name; handler_code_sym }; label_after })
   | Iprobe_is_enabled { name } -> Basic (Op (Probe_is_enabled { name }))
   | Ibeginregion -> Basic (Op Begin_region)
   | Iendregion -> Basic (Op End_region)
@@ -344,10 +360,15 @@ let rec get_end : Mach.instruction -> Mach.instruction =
   | Itrywith _ | Iraise _ ->
     get_end instr.Mach.next
 
+type terminator_info =
+  | Terminator of Cfg.terminator Cfg.instruction
+  | With_next_label of (Label.t -> Cfg.terminator Cfg.instruction)
+  | Complex_terminator
+
 type block_info =
   { instrs : Cfg.basic Cfg.instruction list;
     last : Mach.instruction;
-    terminator : Cfg.terminator Cfg.instruction option
+    terminator : terminator_info
   }
 
 (* [extract_block_info state first] returns a [block_info] containing all the
@@ -356,6 +377,10 @@ type block_info =
    terminator is [None], it is guaranteed that the [last] instruction is not an
    [Iop] (as it would either be part of [instrs] or be a terminator). *)
 let extract_block_info : State.t -> Mach.instruction -> block_info =
+ (* note: useless moves (See `Cfg.is_noop_move`) are no longer removed because
+    we want to compute liveness information on CFG values, and (i) such moves
+    are necessary to compute the live sets and (ii) they can only be identified
+    as useless after register allocation. *)
  fun state first ->
   let rec loop (instr : Mach.instruction) acc =
     let return terminator instrs =
@@ -372,15 +397,18 @@ let extract_block_info : State.t -> Mach.instruction -> block_info =
            (i) such moves are necessary to compute the live sets and (ii) they
            can only be identified as useless after register allocation. *)
         let acc = instr' :: acc in
-        if Cfg.can_raise_basic desc
-        then return None acc
-        else loop instr.next acc
+        loop instr.next acc
       | Terminator terminator ->
-        return (Some (copy_instruction state instr ~desc:terminator)) acc)
+        return (Terminator (copy_instruction state instr ~desc:terminator)) acc
+      | With_next_label terminator ->
+        return
+          (With_next_label
+             (fun label_after ->
+               copy_instruction state instr ~desc:(terminator label_after)))
+          acc)
     | Iend | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _
-    | Itrywith _ ->
-      return None acc
-    | Iraise _ -> return None acc
+    | Itrywith _ | Iraise _ ->
+      return Complex_terminator acc
   in
   loop first []
 
@@ -428,32 +456,28 @@ let rec add_blocks :
         else body
       | Cfg.Never | Cfg.Always _ | Cfg.Parity_test _ | Cfg.Truth_test _
       | Cfg.Float_test _ | Cfg.Int_test _ | Cfg.Switch _ | Cfg.Raise _
-      | Cfg.Tailcall _ | Cfg.Call_no_return _ ->
+      | Cfg.Tailcall_self _ | Cfg.Tailcall _ | Cfg.Call_no_return _ | Cfg.Call _
+      | Cfg.Prim _ | Cfg.Specific_can_raise _ ->
         body
     in
     let can_raise =
       (* Recompute [can_raise] and check that instructions in the middle of the
-         block do not raise, i.e., only the terminator, or the last instruction
-         (when the terminator is just a goto) can raise. *)
-      let terminator_is_goto =
-        match (terminator.Cfg.desc : Cfg.terminator) with
-        | Always _ -> true
-        | Raise _ | Tailcall _ | Call_no_return _ | Never | Parity_test _
-        | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return ->
-          false
-      in
-      let rec check = function
-        | [] -> false
-        | [last] ->
-          let res = Cfg.can_raise_basic last.Cfg.desc in
-          assert ((not res) || terminator_is_goto);
-          res
-        | hd :: tail ->
-          assert (not (Cfg.can_raise_basic hd.Cfg.desc));
-          check tail
-      in
-      let body_can_raise = check body in
-      Cfg.can_raise_terminator terminator.Cfg.desc || body_can_raise
+         block do not raise, i.e., only the terminator can raise. *)
+      List.iter
+        (fun instr ->
+          match instr.Cfg.desc with
+          | Cfg.Op (Specific spec) ->
+            assert (not (Arch.operation_can_raise spec))
+          | Cfg.Op
+              ( Move | Spill | Reload | Const_int _ | Const_float _
+              | Const_symbol _ | Stackoffset _ | Load _ | Store _ | Intop _
+              | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf | Divf | Compf _
+              | Floatofint | Intoffloat | Probe_is_enabled _ | Opaque
+              | Begin_region | End_region | Name_for_debugger _ )
+          | Cfg.Reloadretaddr | Cfg.Pushtrap _ | Cfg.Poptrap | Cfg.Prologue ->
+            ())
+        body;
+      Cfg.can_raise_terminator terminator.Cfg.desc
     in
     State.add_block state ~label:start
       ~block:
@@ -484,18 +508,16 @@ let rec add_blocks :
       start, add_next_block
   in
   match terminator with
-  | Some terminator -> terminate_block ~trap_actions:[] terminator
-  | None -> (
+  | Terminator terminator -> terminate_block ~trap_actions:[] terminator
+  | With_next_label f ->
+    let next, add_next_block = prepare_next_block () in
+    terminate_block ~trap_actions:[] (f next);
+    add_next_block ()
+  | Complex_terminator -> (
     match last.desc with
-    | Iop op ->
-      if not (Mach.operation_can_raise op)
-      then
-        Misc.fatal_error
-          "Cfgize.extract_block_info: unexpected Iop with no terminator";
-      let next, add_next_block = prepare_next_block () in
-      terminate_block ~trap_actions:[]
-        (copy_instruction_no_reg state last ~desc:(Cfg.Always next));
-      add_next_block ()
+    | Iop _ ->
+      Misc.fatal_error
+        "Cfgize.extract_block_info: unexpected Iop as Complex_terminator"
     | Iend ->
       if Label.equal next fallthrough_label
       then
@@ -619,15 +641,13 @@ module Stack_offset_and_exn = struct
     assert (term.stack_offset = invalid_stack_offset);
     let term = check_and_set_stack_offset term ~stack_offset ~traps in
     match term.desc with
-    | Tailcall (Self _) when List.length traps <> 0 || stack_offset <> 0 ->
+    | Tailcall_self _ when List.length traps <> 0 || stack_offset <> 0 ->
       Misc.fatal_error
         "Cfgize.Stack_offset_and_exn.process_terminator: unexpected handler on \
          self tailcall"
-    | Tailcall (Self _)
-    | Never | Return
-    | Tailcall (Func _)
-    | Call_no_return _ | Raise _ | Always _ | Parity_test _ | Truth_test _
-    | Float_test _ | Int_test _ | Switch _ ->
+    | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+    | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall _
+    | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _ ->
       stack_offset, traps, term
 
   let rec process_basic :
@@ -653,10 +673,10 @@ module Stack_offset_and_exn = struct
     | Op
         ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_symbol _
         | Load _ | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf
-        | Mulf | Divf | Compf _ | Floatofint | Intoffloat | Probe _
-        | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
-        | Name_for_debugger _ )
-    | Call _ | Reloadretaddr | Prologue ->
+        | Mulf | Divf | Compf _ | Floatofint | Intoffloat | Probe_is_enabled _
+        | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
+          )
+    | Reloadretaddr | Prologue ->
       stack_offset, traps, instr
 
   (* The argument [stack_offset] has a different meaning from the field

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -352,70 +352,6 @@ let mk_int_test ~lbl ~inv ~imm (cmp : Mach.integer_comparison) : C.int_test =
 let block_is_registered t (block : C.basic_block) =
   Label.Tbl.mem t.cfg.blocks block.start
 
-let add_terminator t (block : C.basic_block) (i : L.instruction)
-    (desc : C.terminator) ~stack_offset ~traps =
-  (* All terminators are followed by a label, except branches we created for
-     fallthroughs in Linear. *)
-  (match desc with
-  | Never -> Misc.fatal_error "Cannot add terminator: Never"
-  | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ -> ()
-  | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
-    if not (Linear_utils.defines_label i.next)
-    then
-      Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
-        Printlinear.instr
-        { i with Linear.next = Linear.end_instr });
-  block.terminator <- create_instruction t desc ~stack_offset i;
-  if Cfg.can_raise_terminator desc then record_exn t block traps;
-  register_block t block traps
-
-let to_basic (mop : Mach.operation) : C.basic =
-  match mop with
-  | Icall_ind -> Call (F Indirect)
-  | Icall_imm { func } -> Call (F (Direct { func_symbol = func }))
-  | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
-    Call (P (External { func_symbol = func; alloc; ty_args; ty_res }))
-  | Iintop Icheckbound -> Call (P (Checkbound { immediate = None }))
-  | Iintop
-      (( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-       | Ipopcnt | Iclz _ | Ictz _ | Ilsr | Iasr | Icomp _ ) as op) ->
-    Op (Intop op)
-  | Iintop_imm (Icheckbound, i) -> Call (P (Checkbound { immediate = Some i }))
-  | Iintop_imm
-      ( (( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
-         | Ipopcnt | Iclz _ | Ictz _ | Ilsl | Ilsr | Iasr | Icomp _ ) as op),
-        i ) ->
-    Op (Intop_imm (op, i))
-  | Ialloc { bytes; dbginfo; mode } -> Call (P (Alloc { bytes; dbginfo; mode }))
-  | Iprobe { name; handler_code_sym } -> Op (Probe { name; handler_code_sym })
-  | Iprobe_is_enabled { name } -> Op (Probe_is_enabled { name })
-  | Istackoffset i -> Op (Stackoffset i)
-  | Iload (c, a, m) -> Op (Load (c, a, m))
-  | Istore (c, a, b) -> Op (Store (c, a, b))
-  | Imove -> Op Move
-  | Ispill -> Op Spill
-  | Ireload -> Op Reload
-  | Iconst_int n -> Op (Const_int n)
-  | Iconst_float n -> Op (Const_float n)
-  | Iconst_symbol n -> Op (Const_symbol n)
-  | Inegf -> Op Negf
-  | Iabsf -> Op Absf
-  | Iaddf -> Op Addf
-  | Isubf -> Op Subf
-  | Imulf -> Op Mulf
-  | Idivf -> Op Divf
-  | Icompf c -> Op (Compf c)
-  | Ifloatofint -> Op Floatofint
-  | Iintoffloat -> Op Intoffloat
-  | Iopaque -> Op Opaque
-  | Ibeginregion -> Op Begin_region
-  | Iendregion -> Op End_region
-  | Ispecific op -> Op (Specific op)
-  | Iname_for_debugger { ident; which_parameter; provenance; is_assignment } ->
-    Op (Name_for_debugger { ident; which_parameter; provenance; is_assignment })
-  | Itailcall_ind | Itailcall_imm _ | Iextcall { returns = false; _ } ->
-    assert false
-
 let rec adjust_traps (i : L.instruction) ~stack_offset ~traps =
   (* We do not emit any executable code for this insn; it only moves the virtual
      stack pointer in the emitter. We do not have a corresponding insn in [Cfg]
@@ -452,6 +388,41 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
      enough information to compute it upfront, but stack_offset is directly
      computed. *)
   let stack_offset, traps, i = adjust_traps i ~stack_offset ~traps in
+  let add_terminator (desc : C.terminator) ~(next : Linear.instruction) =
+    (* All terminators are followed by a label, except branches we created for
+       fallthroughs in Linear. *)
+    (match desc with
+    | Never -> Misc.fatal_error "Cannot add terminator: Never"
+    | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+    | Call _ | Prim _ | Specific_can_raise _ | Switch _ ->
+      ()
+    | Return | Raise _ | Tailcall_self _ | Tailcall _ | Call_no_return _ ->
+      if not (Linear_utils.defines_label i.next)
+      then
+        Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
+          Printlinear.instr
+          { i with Linear.next = L.end_instr });
+    block.terminator <- create_instruction t desc ~stack_offset i;
+    if Cfg.can_raise_terminator desc then record_exn t block traps;
+    register_block t block traps;
+    create_blocks t next block ~stack_offset ~traps
+  in
+  let terminator desc = add_terminator desc ~next:i.next in
+  let terminator_fallthrough (mk_desc : Label.t -> C.terminator) =
+    let fallthrough = get_or_make_label t i.next in
+    let desc = mk_desc fallthrough.label in
+    add_terminator desc ~next:fallthrough.insn
+  in
+  let terminator_call call =
+    terminator_fallthrough (fun label_after -> Call { call; label_after })
+  in
+  let terminator_prim prim =
+    terminator_fallthrough (fun label_after -> Prim { prim; label_after })
+  in
+  let basic desc =
+    block.body <- create_instruction t desc i ~stack_offset :: block.body;
+    create_blocks t i.next block ~stack_offset ~traps
+  in
   match i.desc with
   | Ladjust_stack_offset _ -> assert false
   | Lend ->
@@ -486,50 +457,39 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     then
       Misc.fatal_errorf "Stack offset is %d, but it must be 0 at Lreturn"
         stack_offset;
-    add_terminator t block i Return ~stack_offset ~traps;
-    create_blocks t i.next block ~stack_offset ~traps
-  | Lraise kind ->
-    add_terminator t block i (Raise kind) ~stack_offset ~traps;
-    create_blocks t i.next block ~stack_offset ~traps
+    terminator Return
+  | Lraise kind -> terminator (Raise kind)
   | Lbranch lbl ->
     if !C.verbose then Printf.printf "Lbranch %d\n" lbl;
-    add_terminator t block i (Always lbl) ~stack_offset ~traps;
-    create_blocks t i.next block ~stack_offset ~traps
+    terminator (Always lbl)
   | Lcondbranch (cond, lbl) ->
     (* This representation does not preserve the order of successors. *)
-    let fallthrough = get_or_make_label t i.next in
-    let inv = fallthrough.label in
-    let desc : C.terminator =
-      match (cond : Mach.test) with
-      | Ieventest -> Parity_test { ifso = lbl; ifnot = inv }
-      | Ioddtest -> Parity_test { ifso = inv; ifnot = lbl }
-      | Itruetest -> Truth_test { ifso = lbl; ifnot = inv }
-      | Ifalsetest -> Truth_test { ifso = inv; ifnot = lbl }
-      | Ifloattest cmp -> Float_test (of_cmm_float_test cmp ~lbl ~inv)
-      | Iinttest cmp -> Int_test (mk_int_test cmp ~lbl ~inv ~imm:None)
-      | Iinttest_imm (cmp, n) ->
-        Int_test (mk_int_test cmp ~lbl ~inv ~imm:(Some n))
-    in
-    add_terminator t block i desc ~stack_offset ~traps;
-    create_blocks t fallthrough.insn block ~stack_offset ~traps
+    terminator_fallthrough (fun inv ->
+        match (cond : Mach.test) with
+        | Ieventest -> Parity_test { ifso = lbl; ifnot = inv }
+        | Ioddtest -> Parity_test { ifso = inv; ifnot = lbl }
+        | Itruetest -> Truth_test { ifso = lbl; ifnot = inv }
+        | Ifalsetest -> Truth_test { ifso = inv; ifnot = lbl }
+        | Ifloattest cmp -> Float_test (of_cmm_float_test cmp ~lbl ~inv)
+        | Iinttest cmp -> Int_test (mk_int_test cmp ~lbl ~inv ~imm:None)
+        | Iinttest_imm (cmp, n) ->
+          Int_test (mk_int_test cmp ~lbl ~inv ~imm:(Some n)))
   | Lcondbranch3 (lbl0, lbl1, lbl2) ->
-    let fallthrough = get_or_make_label t i.next in
-    let get_dest lbl = Option.value lbl ~default:fallthrough.label in
-    let it : C.int_test =
-      { imm = Some 1;
-        is_signed = false;
-        lt = get_dest lbl0;
-        eq = get_dest lbl1;
-        gt = get_dest lbl2
-      }
-    in
-    add_terminator t block i (Int_test it) ~stack_offset ~traps;
-    create_blocks t fallthrough.insn block ~stack_offset ~traps
+    terminator_fallthrough (fun l ->
+        let get_dest lbl = Option.value lbl ~default:l in
+        let it : C.int_test =
+          { imm = Some 1;
+            is_signed = false;
+            lt = get_dest lbl0;
+            eq = get_dest lbl1;
+            gt = get_dest lbl2
+          }
+        in
+        Int_test it)
   | Lswitch labels ->
     (* CR-someday gyorsh: get rid of switches entirely and re-generate them
        based on optimization and perf data? *)
-    add_terminator t block i (Switch labels) ~stack_offset ~traps;
-    create_blocks t i.next block ~stack_offset ~traps
+    terminator (Switch labels)
   | Lpushtrap { lbl_handler } ->
     t.trap_handlers <- Label.Set.add lbl_handler t.trap_handlers;
     record_traps t lbl_handler traps;
@@ -559,63 +519,84 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     assert (List.compare_length_with block.body 0 = 0);
     block.is_trap_handler <- true;
     create_blocks t i.next block ~stack_offset ~traps
-  | Lprologue ->
-    let desc = C.Prologue in
-    block.body <- create_instruction t desc i ~stack_offset :: block.body;
-    create_blocks t i.next block ~stack_offset ~traps
-  | Lreloadretaddr ->
-    let desc = C.Reloadretaddr in
-    block.body <- create_instruction t desc i ~stack_offset :: block.body;
-    create_blocks t i.next block ~stack_offset ~traps
+  | Lprologue -> basic C.Prologue
+  | Lreloadretaddr -> basic C.Reloadretaddr
   | Lop mop -> (
+    let basic desc =
+      assert (not (Mach.operation_can_raise mop));
+      basic (C.Op desc)
+    in
     match mop with
-    | Itailcall_ind ->
-      let desc = C.Tailcall (Func Indirect) in
-      add_terminator t block i desc ~stack_offset ~traps;
-      create_blocks t i.next block ~stack_offset ~traps
+    | Itailcall_ind -> terminator (C.Tailcall Indirect)
     | Itailcall_imm { func = func_symbol } ->
       let desc =
         if String.equal func_symbol (C.fun_name t.cfg)
         then
           match t.tailrec_label with
           | None -> Misc.fatal_error "tail call to missing tailrec entry point"
-          | Some destination -> C.Tailcall (Self { destination })
-        else C.Tailcall (Func (Direct { func_symbol }))
+          | Some destination -> C.Tailcall_self { destination }
+        else C.Tailcall (Direct { func_symbol })
       in
-      add_terminator t block i desc ~stack_offset ~traps;
-      create_blocks t i.next block ~stack_offset ~traps
+      terminator desc
     | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
-      let desc =
-        C.Call_no_return { func_symbol = func; alloc; ty_args; ty_res }
-      in
-      add_terminator t block i desc ~stack_offset ~traps;
-      create_blocks t i.next block ~stack_offset ~traps
+      terminator
+        (C.Call_no_return { func_symbol = func; alloc; ty_args; ty_res })
+    | Icall_ind -> terminator_call Indirect
+    | Icall_imm { func } -> terminator_call (Direct { func_symbol = func })
+    | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
+      terminator_prim (External { func_symbol = func; alloc; ty_args; ty_res })
+    | Iintop Icheckbound -> terminator_prim (Checkbound { immediate = None })
+    | Iintop_imm (Icheckbound, i) ->
+      terminator_prim (Checkbound { immediate = Some i })
+    | Ialloc { bytes; dbginfo; mode } ->
+      terminator_prim (Alloc { bytes; dbginfo; mode })
+    | Iprobe { name; handler_code_sym } ->
+      terminator_prim (Probe { name; handler_code_sym })
     | Istackoffset bytes ->
-      let desc = to_basic mop in
+      let desc = C.Op (C.Stackoffset bytes) in
       block.body <- create_instruction t desc i ~stack_offset :: block.body;
       let stack_offset = stack_offset + bytes in
       create_blocks t i.next block ~stack_offset ~traps
-    | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
-    | Ifloatofint | Iintoffloat | Iconst_int _ | Iconst_float _ | Icompf _
-    | Iconst_symbol _ | Icall_ind | Icall_imm _ | Iextcall _
-    | Iload (_, _, _)
-    | Istore (_, _, _)
-    | Ialloc _ | Iintop _
-    | Iintop_imm (_, _)
-    | Iopaque | Iprobe _ | Iprobe_is_enabled _ | Ispecific _ | Ibeginregion
-    | Iendregion | Iname_for_debugger _ ->
-      let desc = to_basic mop in
-      block.body <- create_instruction t desc i ~stack_offset :: block.body;
-      if Mach.operation_can_raise mop
-      then (
-        (* Instruction that can raise is always at the end of a block. *)
-        record_exn t block traps;
-        let fallthrough = get_or_make_label t i.next in
-        let desc : Cfg.terminator = Always fallthrough.label in
-        let i_no_reg = { i with arg = [||]; res = [||]; fdo = Fdo_info.none } in
-        add_terminator t block i_no_reg desc ~stack_offset ~traps;
-        create_blocks t fallthrough.insn block ~stack_offset ~traps)
-      else create_blocks t i.next block ~stack_offset ~traps)
+    | Iintop
+        (( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
+         | Ipopcnt | Iclz _ | Ictz _ | Ilsr | Iasr | Icomp _ ) as op) ->
+      basic (Intop op)
+    | Iintop_imm
+        ( (( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
+           | Ipopcnt | Iclz _ | Ictz _ | Ilsl | Ilsr | Iasr | Icomp _ ) as op),
+          i ) ->
+      basic (Intop_imm (op, i))
+    | Iprobe_is_enabled { name } -> basic (Probe_is_enabled { name })
+    | Iload (c, a, m) -> basic (Load (c, a, m))
+    | Istore (c, a, b) -> basic (Store (c, a, b))
+    | Imove -> basic Move
+    | Ispill -> basic Spill
+    | Ireload -> basic Reload
+    | Iconst_int n -> basic (Const_int n)
+    | Iconst_float n -> basic (Const_float n)
+    | Iconst_symbol n -> basic (Const_symbol n)
+    | Inegf -> basic Negf
+    | Iabsf -> basic Absf
+    | Iaddf -> basic Addf
+    | Isubf -> basic Subf
+    | Imulf -> basic Mulf
+    | Idivf -> basic Divf
+    | Icompf c -> basic (Compf c)
+    | Ifloatofint -> basic Floatofint
+    | Iintoffloat -> basic Intoffloat
+    | Iopaque -> basic Opaque
+    | Ibeginregion -> basic Begin_region
+    | Iendregion -> basic End_region
+    | Iname_for_debugger { ident; which_parameter; provenance; is_assignment }
+      ->
+      basic
+        (Name_for_debugger { ident; which_parameter; provenance; is_assignment })
+    | Ispecific op ->
+      if Arch.operation_can_raise op
+      then basic (Specific op)
+      else
+        terminator_fallthrough (fun label_after ->
+            Specific_can_raise { op; label_after }))
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -593,10 +593,10 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
         (Name_for_debugger { ident; which_parameter; provenance; is_assignment })
     | Ispecific op ->
       if Arch.operation_can_raise op
-      then basic (Specific op)
-      else
+      then
         terminator_fallthrough (fun label_after ->
-            Specific_can_raise { op; label_after }))
+            Specific_can_raise { op; label_after })
+      else basic (Specific op))
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -98,6 +98,8 @@ let block (block : C.basic_block) =
       let l = Label.Set.min_elt labels in
       block.terminator <- { block.terminator with desc = Always l }
   | Switch labels -> simplify_switch block labels
-  | Call_no_return _ | Tailcall (Self _ | Func _) | Raise _ | Return -> ()
+  | Raise _ | Return | Tailcall_self _ | Tailcall _ | Call_no_return _ | Call _
+  | Prim _ | Specific_can_raise _ ->
+    ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/dune
+++ b/dune
@@ -232,6 +232,7 @@
   cfg_to_linear
   cfg_with_layout
   cfg_dataflow
+  cfg_deadcode
   cfg_liveness
   cfg_regalloc_utils
   cfg_to_linear_desc
@@ -742,6 +743,7 @@
   (cfg_to_linear.mli as compiler-libs/cfg_to_linear.mli)
   (cfg_with_layout.mli as compiler-libs/cfg_with_layout.mli)
   (cfg_dataflow.mli as compiler-libs/cfg_dataflow.mli)
+  (cfg_deadcode.mli as compiler-libs/cfg_deadcode.mli)
   (cfg_liveness.mli as compiler-libs/cfg_liveness.mli)
   (cfg_regalloc_utils.mli as compiler-libs/cfg_regalloc_utils.mli)
   (cfg_to_linear_desc.mli as compiler-libs/cfg_to_linear_desc.mli)
@@ -1167,6 +1169,18 @@
   (.ocamloptcomp.objs/byte/cfg_dataflow.cmti
    as
    compiler-libs/cfg_dataflow.cmti)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmi
+   as
+   compiler-libs/cfg_deadcode.cmi)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmo
+   as
+   compiler-libs/cfg_deadcode.cmo)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmt
+   as
+   compiler-libs/cfg_deadcode.cmt)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmti
+   as
+   compiler-libs/cfg_deadcode.cmti)
   (.ocamloptcomp.objs/byte/cfg_liveness.cmi
    as
    compiler-libs/cfg_liveness.cmi)
@@ -1462,6 +1476,9 @@
   (.ocamloptcomp.objs/native/cfg_dataflow.cmx
    as
    compiler-libs/cfg_dataflow.cmx)
+  (.ocamloptcomp.objs/native/cfg_deadcode.cmx
+   as
+   compiler-libs/cfg_deadcode.cmx)
   (.ocamloptcomp.objs/native/cfg_liveness.cmx
    as
    compiler-libs/cfg_liveness.cmx)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -237,7 +237,8 @@ module Inlining = struct
           | Default_inlined | Unroll _ ->
             (* Closure ignores completely [@unrolled] attributes, so it seems
                safe to do the same. *)
-            ( Call_site_inlining_decision_type.Definition_says_inline,
+            ( Call_site_inlining_decision_type.Definition_says_inline
+                { was_inline_always = false },
               Inlinable code )
         in
         Inlining_report.record_decision_at_call_site_for_known_function ~tracker

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -190,7 +190,8 @@ val inlining_arguments : t -> Inlining_arguments.t
 
 val set_inlining_arguments : Inlining_arguments.t -> t -> t
 
-val enter_inlined_apply : called_code:Code.t -> apply:Apply.t -> t -> t
+val enter_inlined_apply :
+  called_code:Code.t -> apply:Apply.t -> was_inline_always:bool -> t -> t
 
 val generate_phantom_lets : t -> bool
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -59,7 +59,8 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
        inside of [speculative_inlining] we will always have [unroll_to] = None.
        We are not disabling unrolling when speculating, it just happens that no
        unrolling can happen while speculating right now. *)
-    Inlining_transforms.inline dacc ~apply ~unroll_to:None function_type
+    Inlining_transforms.inline dacc ~apply ~unroll_to:None
+      ~was_inline_always:false function_type
   in
   let scope = DE.get_continuation_scope (DA.denv dacc) in
   let dummy_toplevel_cont =
@@ -148,7 +149,11 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
     |> Code_metadata.inlining_decision
   in
   if Function_decl_inlining_decision_type.must_be_inlined decision
-  then Definition_says_inline
+  then
+    Definition_says_inline
+      { was_inline_always =
+          Function_decl_inlining_decision_type.has_attribute_inline decision
+      }
   else if Function_decl_inlining_decision_type.cannot_be_inlined decision
   then Definition_says_not_to_inline
   else if env_prohibits_inlining

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -83,7 +83,7 @@ let wrap_inlined_body_for_exn_extra_args ~extra_args ~apply_exn_continuation
     ~apply_exn_continuation ~apply_return_continuation ~result_arity
     ~make_inlined_body ~apply_cont_create ~let_cont_create
 
-let inline dacc ~apply ~unroll_to function_decl =
+let inline dacc ~apply ~unroll_to ~was_inline_always function_decl =
   let callee = Apply.callee apply in
   let args = Apply.args apply in
   let apply_return_continuation = Apply.continuation apply in
@@ -103,7 +103,9 @@ let inline dacc ~apply ~unroll_to function_decl =
     | Need_meet -> Rec_info_expr.unknown
     | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
   in
-  let denv = DE.enter_inlined_apply ~called_code:code ~apply denv in
+  let denv =
+    DE.enter_inlined_apply ~called_code:code ~apply ~was_inline_always denv
+  in
   let params_and_body = Code.params_and_body code in
   Function_params_and_body.pattern_match params_and_body
     ~f:(fun

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.mli
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.mli
@@ -20,5 +20,6 @@ val inline :
   Downwards_acc.t ->
   apply:Apply.t ->
   unroll_to:int option ->
+  was_inline_always:bool ->
   Flambda2_types.Function_type.t ->
   Downwards_acc.t * Expr.t

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -165,9 +165,10 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
             "[@inlined] attribute was not used on this function \
              application{Do_not_inline}";
       None
-    | Inline { unroll_to } ->
+    | Inline { unroll_to; was_inline_always } ->
       let dacc, inlined =
-        Inlining_transforms.inline dacc ~apply ~unroll_to function_type
+        Inlining_transforms.inline dacc ~apply ~unroll_to ~was_inline_always
+          function_type
       in
       Some (dacc, inlined)
   in

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -33,7 +33,7 @@ type t =
       }
   | Attribute_always
   | Attribute_unroll of int
-  | Definition_says_inline
+  | Definition_says_inline of { was_inline_always : bool }
   | Speculatively_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
@@ -49,6 +49,9 @@ type can_inline = private
       { warn_if_attribute_ignored : bool;
         because_of_definition : bool
       }
-  | Inline of { unroll_to : int option }
+  | Inline of
+      { unroll_to : int option;
+        was_inline_always : bool
+      }
 
 val can_inline : t -> can_inline

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -135,6 +135,13 @@ let must_be_inlined t =
   | Must_be_inlined -> true
   | Cannot_be_inlined | Could_possibly_be_inlined -> false
 
+let has_attribute_inline t =
+  match t with
+  | Attribute_inline -> true
+  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _ | Stub
+  | Small_function _ | Speculatively_inlinable _ | Functor _ | Recursive ->
+    false
+
 let cannot_be_inlined t =
   match behaviour t with
   | Cannot_be_inlined -> true

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -38,6 +38,8 @@ val report : Format.formatter -> t -> unit
 
 val must_be_inlined : t -> bool
 
+val has_attribute_inline : t -> bool
+
 val cannot_be_inlined : t -> bool
 
 val equal : t -> t -> bool

--- a/middle_end/flambda2/terms/inlining_state.ml
+++ b/middle_end/flambda2/terms/inlining_state.ml
@@ -19,7 +19,7 @@ type t =
     depth : int
   }
 
-let increment_depth t = { t with depth = t.depth + 1 }
+let increment_depth t ~by = { t with depth = t.depth + by }
 
 let default ~round = { arguments = Inlining_arguments.create ~round; depth = 0 }
 

--- a/middle_end/flambda2/terms/inlining_state.mli
+++ b/middle_end/flambda2/terms/inlining_state.mli
@@ -28,7 +28,7 @@ val create : arguments:Inlining_arguments.t -> depth:int -> t
 
 val depth : t -> int
 
-val increment_depth : t -> t
+val increment_depth : t -> by:int -> t
 
 val is_depth_exceeded : t -> bool
 

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -113,10 +113,15 @@ module Inlining = struct
     | Round of int
     | Default
 
+  let depth_scaling_factor = 10 (* See [Downwards_env.enter_inlined_apply] *)
+
   let max_depth round_or_default =
-    match round_or_default with
-    | Round round -> IH.get ~key:round !I.max_depth
-    | Default -> D.max_depth
+    let depth =
+      match round_or_default with
+      | Round round -> IH.get ~key:round !I.max_depth
+      | Default -> D.max_depth
+    in
+    depth * depth_scaling_factor
 
   let max_rec_depth round_or_default =
     match round_or_default with

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -77,6 +77,9 @@ module Inlining : sig
     | Round of int
     | Default
 
+  val depth_scaling_factor : int
+
+  (** [max_depth] returns the user's value multipled by [depth_scaling_factor]. *)
   val max_depth : round_or_default -> int
 
   val max_rec_depth : round_or_default -> int


### PR DESCRIPTION
Change the `Cfg.basic` and `Cfg.terminator` such that only terminators can raise.